### PR TITLE
Move sampling settings to scenario_config

### DIFF
--- a/simulationTool/components/Ensemble/EnsembleInputs/EnsembleInput.vue
+++ b/simulationTool/components/Ensemble/EnsembleInputs/EnsembleInput.vue
@@ -19,7 +19,7 @@ export default {
         "modelValue": {
             type: [Array, Boolean],
             default: (props) => {
-                const defaultValue = DEFAULT_VALUE_MAP[props.data?.schema?.type] || undefined
+                const defaultValue = DEFAULT_VALUE_MAP[props.data?.schema?.type] || []
                 if (props.data.schema.minimum !== undefined) {
                     defaultValue[0] = props.data.schema.minimum;
                 }
@@ -36,7 +36,7 @@ export default {
     },
     data() {
         return {
-            internalValue: [...this.modelValue],
+            internalValue: Array.isArray(this.modelValue) ? [...this.modelValue] : [],
         }
     },
     watch: {

--- a/simulationTool/components/Ensemble/EnsembleInputs/EnsembleInput.vue
+++ b/simulationTool/components/Ensemble/EnsembleInputs/EnsembleInput.vue
@@ -87,7 +87,7 @@ export default {
             @tag="addTag"
         />
         <RangeSlider
-            v-if="data.schema.type === 'number'"
+            v-if="['number', 'integer'].includes(data.schema.type)"
             v-model="internalValue"
             :min="data.schema.minimum"
             :max="data.schema.maximum"


### PR DESCRIPTION
This transforms the ensemble UI to add the sample size and the sampling method to the scenario_config instead of the ensemble itself. Compare the corresponding PR in the UMP: https://github.com/citysciencelab/urban-model-platform/pull/41.

## Preview

![image](https://github.com/user-attachments/assets/dc09498f-3474-4ea0-b4e1-f98ad4ee7a70)
