### PR TITLE
fix: ensures the state is set correctly

### DIFF
--- a/simulationTool/components/SideMenu.vue
+++ b/simulationTool/components/SideMenu.vue
@@ -12,6 +12,9 @@ export default {
         ]),
         ...mapGetters("Modules/Login", [
             "loggedIn"
+        ]),
+        ...mapGetters("Menu", [
+            "currentComponentName"
         ])
     },
     methods: {
@@ -19,13 +22,17 @@ export default {
             "setMode"
         ]),
         ...mapMutations("Menu", [
-            "setCurrentComponent"
+            "setCurrentComponent",
+            "setCurrentComponentPropsName"
         ]),
         ...mapActions("Menu", [
             "resetMenu"
         ]),
         closeSimulationTool() {
             this.restoreDefaultLayout();
+            if (this.currentComponentName('secondaryMenu') !== 'Simulationen') {
+                this.setCurrentComponentPropsName({side: 'secondaryMenu', name: "Simulationen"})
+            }
             this.resetMenu('secondaryMenu');
         },
         applyCustomLayout() {


### PR DESCRIPTION
This fixes the bug the following bug:

This update resolves an issue where the sidebar's state was incorrectly set when using the sidebar's close button while the login window was open in the main menu. The problem occurred due to the restoreDefaultLayout() function from the masterportal module, which inadvertently reset the sidebar's state.

Please notice:
This might become problematic if more than one state for the secondaryMenu is desired. We might want to refactor the toolbar in that case.