### PR TITLE
Update creation of ensemble defaults

### DIFF
--- a/simulationTool/components/Ensemble/EnsembleCreation.vue
+++ b/simulationTool/components/Ensemble/EnsembleCreation.vue
@@ -104,7 +104,6 @@ export default {
                     if (inputConfig.schema.maximum !== undefined) {
                         defaultValue[1] = inputConfig.schema.maximum;
                     }
-                    console.log(key, defaultValue);
                     this.updateExecutionValue(process.id, key, defaultValue);
                 });
             }

--- a/simulationTool/components/Ensemble/EnsembleCreation.vue
+++ b/simulationTool/components/Ensemble/EnsembleCreation.vue
@@ -6,6 +6,12 @@ import Config from "../../../../portal/simulation/config";
 import EnsembleInput from "./EnsembleInput.vue";
 import AsyncWrapper from "../AsyncWrapper.vue";
 
+const DEFAULT_VALUE_MAP = {
+    number: [0, 100],
+    boolean: [],
+    string: []
+};
+
 export default {
     name: "EnsembleCreation",
     components: {
@@ -48,15 +54,9 @@ export default {
                         return this.fetchProcess(process.id);
                     })
                 )).filter(process => process);
-                // add default values for sample size and sampling method
-                for (const process of this.processDetails) {
-                    if (!this.creationValues?.[process.id]?.sample_size) {
-                        this.updateExecutionValue(process.id, 'sample_size', 10);
-                    }
-                    if (!this.creationValues?.[process.id]?.sampling_method) {
-                        this.updateExecutionValue(process.id, 'sampling_method', 'lhs');
-                    }
-                }
+
+                this.setDefaultExecutionValues();
+
                 // remove values for processes that are not selected anymore
                 Object.keys(this.creationValues)
                     .filter(key => !['name', 'description'].includes(key))
@@ -84,6 +84,32 @@ export default {
         ...mapActions("Modules/SimulationTool", [
             "fetchEnsembles"
         ]),
+        setDefaultExecutionValues() {
+            // add default values for sample size and sampling method
+            for (const process of this.processDetails) {
+                if (!this.creationValues?.[process.id]?.sample_size) {
+                    this.updateExecutionValue(process.id, 'sample_size', 10);
+                }
+                if (!this.creationValues?.[process.id]?.sampling_method) {
+                    this.updateExecutionValue(process.id, 'sampling_method', 'lhs');
+                }
+
+                // add default values for input parameters
+                Object.keys(process.inputs).forEach((key) => {
+                    const inputConfig = process.inputs[key];
+                    const defaultValue = DEFAULT_VALUE_MAP[inputConfig?.schema?.type] || []
+                    if (inputConfig.schema.minimum !== undefined) {
+                        defaultValue[0] = inputConfig.schema.minimum;
+                    }
+                    if (inputConfig.schema.maximum !== undefined) {
+                        defaultValue[1] = inputConfig.schema.maximum;
+                    }
+                    console.log(key, defaultValue);
+                    this.updateExecutionValue(process.id, key, defaultValue);
+                });
+            }
+
+        },
         updateExecutionValue(processId, key, value) {
             this.creationValues[processId] = this.creationValues[processId] || {};
             this.creationValues[processId][key] = value;

--- a/simulationTool/components/Ensemble/EnsembleInput.vue
+++ b/simulationTool/components/Ensemble/EnsembleInput.vue
@@ -3,12 +3,6 @@ import multiselect from "vue-multiselect";
 import RangeSlider from "../RangeSlider.vue";
 import isEqual from "lodash/isEqual";
 
-const DEFAULT_VALUE_MAP = {
-    number: [0, 100],
-    boolean: [],
-    string: []
-};
-
 export default {
     name: "EnsembleInput",
     components: {
@@ -17,17 +11,7 @@ export default {
     },
     props: {
         "modelValue": {
-            type: [Array, Boolean],
-            default: (props) => {
-                const defaultValue = DEFAULT_VALUE_MAP[props.data?.schema?.type] || []
-                if (props.data.schema.minimum !== undefined) {
-                    defaultValue[0] = props.data.schema.minimum;
-                }
-                if (props.data.schema.maximum !== undefined) {
-                    defaultValue[1] = props.data.schema.maximum;
-                }
-                return defaultValue;
-            }
+            type: [Array, Boolean]
         },
         "data": {
             type: Object,


### PR DESCRIPTION
This moves the creation of default values for ensembles from the input fields to the form. This ensures that default values will be send to the backend correctly.