### PR TITLE
Add 3 second timeout before fetching layer

### DIFF
--- a/simulationTool/components/Job/JobDetails.vue
+++ b/simulationTool/components/Job/JobDetails.vue
@@ -54,7 +54,9 @@ export default {
         job: function(newJob) {
             if (newJob) {
                 this.fetchJobResultData();
-                this.fetchJobLayer(newJob);
+                setTimeout(() => {
+                    this.fetchJobLayer(newJob);
+                }, 3000);
             }
         }
     },


### PR DESCRIPTION
This adds a three second timeout before fetching a layer for a job to avoid timing issues with the backend.