### PR TITLE
fix: fixing css and show information only if shared

### DIFF
--- a/simulationTool/components/Comments/CommentsPanel.vue
+++ b/simulationTool/components/Comments/CommentsPanel.vue
@@ -148,6 +148,7 @@ export default {
         flex-direction: column;
         justify-content: space-between;
         gap: 1rem;
+        height: 100%;
 
         ul.comments {
             list-style-type: none;

--- a/simulationTool/components/Ensemble/EnsembleDetails.vue
+++ b/simulationTool/components/Ensemble/EnsembleDetails.vue
@@ -339,19 +339,21 @@ export default {
                         </div>
                     </div>
                 </AsyncWrapper>
-                <div class="notes">
-                    <h4>{{ $t('additional:modules.tools.simulationTool.notes') }}</h4>
-                    <CommentsPanel
-                        endPoint="ensembles"
-                        :entityId="ensemble.id?.toString()"
-                    />
-                </div>
-                <div class="sharing">
-                    <h4>{{ $t('additional:modules.tools.simulationTool.sharing') }}</h4>
-                    <SharingPanel
-                        endPoint="ensembles"
-                        :entityId="ensemble.id?.toString()"
-                    />
+                <div class="panel-container">
+                    <div class="notes">
+                        <h4>{{ $t('additional:modules.tools.simulationTool.notes') }}</h4>
+                        <CommentsPanel
+                            endPoint="ensembles"
+                            :entityId="ensemble.id?.toString()"
+                        />
+                    </div>
+                    <div class="sharing">
+                        <h4>{{ $t('additional:modules.tools.simulationTool.sharing') }}</h4>
+                        <SharingPanel
+                            endPoint="ensembles"
+                            :entityId="ensemble.id?.toString()"
+                        />
+                    </div>
                 </div>
                 <div class="toolbar">
                     <button
@@ -368,157 +370,126 @@ export default {
 </template>
 
 <style lang="scss" scoped>
-    .ensemble-details {
-        max-height: 100%;
+.ensemble-details {
+    max-height: 100%;
+    display: flex;
+    flex-direction: column;
+    padding: 1rem;
+
+    .details-body {
         display: flex;
         flex-direction: column;
-        padding: 1rem;
+        gap: 1rem;
+        overflow: hidden;
+        flex: 1;
 
-        .details-body {
-            display: grid;
-            gap: 1rem;
-            grid-template-areas:
-                "header header"
-                "models models"
-                "jobs jobs"
-                "notes sharing"
-                "toolbar toolbar";
-            grid-template-columns: 1fr 1fr;
-            grid-template-rows: auto auto auto auto auto;
-            overflow: hidden;
+        ul {
+            list-style: none;
+            padding-left: .5rem;
 
-            ul {
-                list-style: none;
-                padding-left: .5rem;
-
-                li {
-                    margin-bottom: .5rem;
-
-                    i {
-                        margin-right: .25rem;
-                    }
-                }
-            }
-
-            .job-table-wrapper {
-                overflow: auto;
-                max-height: calc(100% - 2.5rem);;
-            }
-
-            .job-list-table {
-                width: 100%;
-                table-layout: fixed;
-                border-collapse: collapse;
-
-                th, td {
-                    padding: .5rem;
-                    text-align: left;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-
-                    &:not(:last-child) {
-                        border-right: 2px solid var(--bs-default);
-                    }
-
-                    &.action-column {
-                        width: 40px;
-                        padding: 0;
-                    }
-                }
-
-                th {
-                    white-space: nowrap;
-                }
-
-                td > div {
-                    white-space: normal;
-                    display: -webkit-box;
-                    line-clamp: 2;
-                    -webkit-line-clamp: 2;
-                    -webkit-box-orient: vertical;
-                    overflow: hidden;
-                    text-overflow: ellipsis;
-                    word-break: break-word;
-                }
-
-                div.status {
-                    display: inline-block;
-                    padding: .25rem .5rem;
-                    border-radius: .5rem;
-                    font-size: .875rem;
-                    font-weight: 500;
-                    color: white;
-
-                    &.accepted {
-                        background-color: var(--bs-info);
-                    }
-
-                    &.running {
-                        background-color: var(--bs-warning);
-                    }
-
-                    &.successful {
-                        background-color: var(--bs-success);
-                    }
-
-                    &.dismissed {
-                        background-color: var(--bs-secondary);
-                    }
-
-                    &.failed {
-                        background-color: var(--bs-danger);
-                    }
-                }
-            }
-
-            .details-header {
-                grid-area: header;
-            }
-
-            .models {
-                overflow: hidden;
-                grid-area: models;
-                display: flex;
-                flex-direction: column;
-                flex-grow: 1;
-                overflow: auto;
-                min-height: 0;
-            }
-
-            .jobs {
-                overflow: hidden;
-                grid-area: jobs;
-                min-height: 200px;
-            }
-
-            .toolbar {
-                grid-area: toolbar;
-                display: flex;
-                justify-content: flex-end;
-            }
-
-            .notes {
-                grid-area: notes;
-                overflow: hidden;
-                display: inherit;
-            }
-
-            .sharing {
-                grid-area: sharing;
-                overflow: hidden;
-                display: inherit;
-            }
-
-            .scenario-list {
-
-                strong {
-                    padding-right: 10px;
-                }
-
-                button {
-                    padding: 0px;
+            li {
+                margin-bottom: .5rem;
+                i {
+                    margin-right: .25rem;
                 }
             }
         }
+
+        .details-header {
+            margin-bottom: 1rem;
+        }
+
+        .models {
+            overflow: auto;
+            flex: 1;
+            min-height: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .jobs {
+            overflow: auto;
+            min-height: 200px;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 0.5rem;
+        }
+
+        .job-table-wrapper {
+            overflow: auto;
+            max-height: 100%;
+        }
+
+        .job-list-table {
+            width: 100%;
+            table-layout: fixed;
+            border-collapse: collapse;
+
+            th, td {
+                padding: .5rem;
+                text-align: left;
+                overflow: hidden;
+                text-overflow: ellipsis;
+
+                &:not(:last-child) {
+                    border-right: 2px solid var(--bs-default);
+                }
+
+                &.action-column {
+                    width: 40px;
+                    padding: 0;
+                }
+            }
+
+            th {
+                white-space: nowrap;
+            }
+
+            td > div {
+                white-space: normal;
+                display: -webkit-box;
+                line-clamp: 2;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                word-break: break-word;
+            }
+
+            .status {
+                display: inline-block;
+                padding: .25rem .5rem;
+                border-radius: .5rem;
+                font-size: .875rem;
+                font-weight: 500;
+                color: white;
+            }
+        }
+
+        .panel-container {
+            display: flex;
+            gap: 1rem;
+            overflow: hidden;
+            flex: 1;
+            align-items: stretch;
+        }
+
+        .toolbar {
+            display: flex;
+            justify-content: flex-end;
+            margin-top: 1rem;
+        }
+
+        .notes, .sharing {
+            flex: 1;
+            min-height: 0;            
+            display: flex;
+            flex-direction: column;
+            overflow: auto;
+        }
     }
+}
+
 </style>

--- a/simulationTool/components/Job/JobDetails.vue
+++ b/simulationTool/components/Job/JobDetails.vue
@@ -266,20 +266,21 @@ export default {
                         </div>
                     </AsyncWrapper>
                 </div>
-
-                <div class="notes" v-if="this.loggedIn">
-                    <h4>{{ $t('additional:modules.tools.simulationTool.notes') }}</h4>
-                    <CommentsPanel
-                        endPoint="jobs"
-                        :entityId="job.jobID"
-                    />
-                </div>
-                <div class="sharing" v-if="this.loggedIn">
-                    <h4>{{ $t('additional:modules.tools.simulationTool.sharing') }}</h4>
-                    <SharingPanel
-                        endPoint="jobs"
-                        :entityId="job.jobID?.toString()"
-                    />
+                <div class="panel-container">
+                    <div class="notes" v-if="this.loggedIn">
+                        <h4>{{ $t('additional:modules.tools.simulationTool.notes') }}</h4>
+                        <CommentsPanel
+                            endPoint="jobs"
+                            :entityId="job.jobID"
+                        />
+                    </div>
+                    <div class="sharing" v-if="this.loggedIn">
+                        <h4>{{ $t('additional:modules.tools.simulationTool.sharing') }}</h4>
+                        <SharingPanel
+                            endPoint="jobs"
+                            :entityId="job.jobID?.toString()"
+                        />
+                    </div>
                 </div>
             </div>
         </AsyncWrapper>
@@ -292,72 +293,21 @@ export default {
     display: flex;
     flex-direction: column;
     padding: 1rem;
-    overflow: hidden;
 
     .details-body {
-        overflow: hidden;
-        display: grid;
+        display: flex;
+        flex-direction: column;
         gap: 1rem;
-        grid-template-areas:
-            "title title"
-            "subtitle status"
-            "links links"
-            "parameter filter"
-            "charts charts"
-            "notes sharing";
-        grid-template-columns: 1fr 1fr;
+        flex: 1;
+        overflow: hidden;
 
         .links {
-            overflow: hidden;
-            grid-area: links;
 
             ul {
                 list-style: none;
                 padding: 0;
                 margin: 0;
             }
-        }
-
-        .title {
-            grid-area: title;
-            overflow: hidden;
-        }
-
-        .subtitle {
-            grid-area: subtitle;
-            overflow: hidden;
-        }
-
-        .status-wrapper {
-            grid-area: status;
-            overflow: hidden;
-        }
-
-        .parameter {
-            grid-area: parameter;
-            overflow: hidden;
-        }
-
-        .filter {
-            grid-area: filter;
-            overflow: hidden;
-        }
-
-        .charts {
-            grid-area: charts;
-            overflow: hidden;
-        }
-
-        .notes {
-            grid-area: notes;
-            overflow: hidden;
-            display: inherit;
-        }
-
-        .sharing {
-            grid-area: sharing;
-            overflow: hidden;
-            display: inherit;
         }
 
         .diagram-wrapper {
@@ -367,5 +317,21 @@ export default {
             padding: 20px;
         }
     }
+
+    .panel-container {
+            display: flex;
+            gap: 1rem;
+            overflow: hidden;
+            flex: 1;
+            align-items: stretch;
+        }
+
+    .notes, .sharing {
+            flex: 1;
+            min-height: 0;            
+            display: flex;
+            flex-direction: column;
+            overflow: auto;
+        }
 }
 </style>

--- a/simulationTool/components/Sharing/SharingPanel.vue
+++ b/simulationTool/components/Sharing/SharingPanel.vue
@@ -96,7 +96,7 @@ export default {
 <template>
     <div class="sharing-panel">
         <div>
-            <span>{{ $t('additional:modules.tools.simulationTool.currentlySharedWith')}}:</span>
+            <span v-show="users.length">{{ $t('additional:modules.tools.simulationTool.currentlySharedWith')}}:</span>
             <AsyncWrapper :asyncState="requestState">
                 <ul class="users">
                     <li
@@ -139,6 +139,7 @@ export default {
         flex-direction: column;
         justify-content: space-between;
         gap: 1rem;
+        height: 100%;
 
         ul.users {
             display: flex;


### PR DESCRIPTION
This PR fixes some css:
- Once comments were written, the sharing element had an offset. 
- Sharing information is only shown when shared

When shared:
![image](https://github.com/user-attachments/assets/8eeccf33-b3fc-4b05-a4c5-8545a5f84573)

When not shared:
![image](https://github.com/user-attachments/assets/b2414b5f-64d1-428b-b77d-689410d5600f)
