### PR TITLE
Auto refresh ensembles if it has running jobs

### DIFF
--- a/simulationTool/components/Ensemble/EnsembleList.vue
+++ b/simulationTool/components/Ensemble/EnsembleList.vue
@@ -41,6 +41,9 @@ export default {
             }
         }
     },
+    mounted() {
+        this.fetchEnsembles();
+    },
     methods: {
         ...mapMutations("Modules/SimulationTool", [
             "setMode",

--- a/simulationTool/components/Job/JobList.vue
+++ b/simulationTool/components/Job/JobList.vue
@@ -72,6 +72,9 @@ export default {
             }
         }
     },
+    mounted() {
+        this.fetchJobs();
+    },
     methods: {
         ...mapMutations("Modules/SimulationTool", [
             "setMode",


### PR DESCRIPTION
This reloads the jobs of an ensemble every 5000ms until no job has the status "running".
It also adds code that reloads the entity lists on every mount of the corresponding node. 