### PR TITLE
Use api endpoint from config

### DIFF
--- a/simulationTool/components/Comments/CommentsPanel.vue
+++ b/simulationTool/components/Comments/CommentsPanel.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from "vuex";
 import AsyncWrapper from '../AsyncWrapper.vue';
 import UserDisplay from "../UserDisplay.vue";
+import Config from "../../../../portal/simulation/config";
 
 export default {
     name: "CommentsPanel",
@@ -47,7 +48,7 @@ export default {
             }
             try {
                 this.requestState.loading = true;
-                const response = await fetch(`/api/${this.endPoint}/${this.entityId}/comments`,{
+                const response = await fetch(`${Config.simulationApiUrl}/${this.endPoint}/${this.entityId}/comments`,{
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders
@@ -71,7 +72,7 @@ export default {
             }
             try {
                 this.requestState.loading = true;
-                const response = await fetch(`/api/${this.endPoint}/${this.entityId}/comments`,{
+                const response = await fetch(`${Config.simulationApiUrl}/${this.endPoint}/${this.entityId}/comments`,{
                     method: 'POST',
                     headers: {
                         "Content-Type": "application/json",

--- a/simulationTool/components/Ensemble/EnsembleCreation.vue
+++ b/simulationTool/components/Ensemble/EnsembleCreation.vue
@@ -40,8 +40,7 @@ export default {
             executionRequestState: {
                 loading: false,
                 error: null
-            },
-            apiUrl: Config.simulationApiUrl
+            }
         };
     },
     watch: {
@@ -135,7 +134,7 @@ export default {
             }
             try {
                 this.processexecutionRequestState.loading = true;
-                const response = await fetch(`/api/processes/${processId}`,{
+                const response = await fetch(`${Config.simulationApiUrl}/processes/${processId}`,{
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders
@@ -188,7 +187,7 @@ export default {
 
                 try {
                     this.executionRequestState.loading = true;
-                    const response = await fetch('/api/ensembles', {
+                    const response = await fetch(`${Config.simulationApiUrl}/ensembles`, {
                         method: "POST",
                         body: JSON.stringify({
                             name,

--- a/simulationTool/components/Ensemble/EnsembleDetails.vue
+++ b/simulationTool/components/Ensemble/EnsembleDetails.vue
@@ -3,6 +3,7 @@ import { mapMutations, mapGetters } from "vuex";
 import SectionHeader from "../SectionHeader.vue";
 import AsyncWrapper from "../AsyncWrapper.vue";
 import CommentsPanel from "../Comments/CommentsPanel.vue"
+import Config from "../../../../portal/simulation/config";
 import UserDisplay from "../UserDisplay.vue";
 import PopConfirm from "../PopConfirm.vue";
 import SharingPanel from "../Sharing/SharingPanel.vue";
@@ -118,7 +119,7 @@ export default {
             }
             try {
                 this.ensembleRequestState.loading = true;
-                const response = await fetch(`/api/ensembles/${ensembleId}`,{
+                const response = await fetch(`${Config.simulationApiUrl}/ensembles/${ensembleId}`,{
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders
@@ -144,7 +145,7 @@ export default {
                     window.clearInterval(this.intervalId);
                 }
                 this.ensembleJobsRequestState.loading = true;
-                const response = await fetch(`/api/ensembles/${this.selectedEnsembleId}/jobs`,{
+                const response = await fetch(`${Config.simulationApiUrl}/ensembles/${this.selectedEnsembleId}/jobs`,{
                     headers: {
                         "Content-Type": "application/json",
                         Authorization: `Bearer ${this.accessToken}`
@@ -230,7 +231,7 @@ export default {
 
             try {
                 this.ensembleExecutionRequestState.loading = true;
-                const response = await fetch(`/api/ensembles/${this.selectedEnsembleId}/execute`,{
+                const response = await fetch(`${Config.simulationApiUrl}/ensembles/${this.selectedEnsembleId}/execute`,{
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders
@@ -259,7 +260,7 @@ export default {
 
             try {
                 this.ensembleJobsRequestState.loading = true;
-                    const response = await fetch(`/api/ensembles/${this.selectedEnsembleId}/jobs/${jobId}`,{
+                    const response = await fetch(`${Config.simulationApiUrl}/ensembles/${this.selectedEnsembleId}/jobs/${jobId}`,{
                         method: 'DELETE',
                         headers: {
                             "Content-Type": "application/json",
@@ -301,7 +302,7 @@ export default {
                 Authorization: `Bearer ${this.accessToken}`
             };
             for (const job of this.selectedJobs) {
-                await fetch(`/api/ensembles/${this.ensemble.id}/addjob/${job.jobID}`, {
+                await fetch(`${Config.simulationApiUrl}/ensembles/${this.ensemble.id}/addjob/${job.jobID}`, {
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders

--- a/simulationTool/components/Job/JobDetails.vue
+++ b/simulationTool/components/Job/JobDetails.vue
@@ -5,6 +5,7 @@ import Diagramm from "../Diagramm/Diagramm.vue";
 import AsyncWrapper from "../AsyncWrapper.vue";
 import CommentsPanel from "../Comments/CommentsPanel.vue"
 import SharingPanel from "../Sharing/SharingPanel.vue"
+import Config from "../../../../portal/simulation/config";
 
 export default {
     name: "JobDetails",
@@ -74,7 +75,7 @@ export default {
 
             try {
                 this.jobRequestState.loading = true;
-                const response = await fetch(`/api/jobs/${jobId}`, {
+                const response = await fetch(`${Config.simulationApiUrl}/jobs/${jobId}`, {
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders
@@ -328,13 +329,13 @@ export default {
         flex: 0 1 auto;
     }
 
-    .details-body, 
-    .panel-container, 
-    .charts, 
-    .links, 
-    .filter, 
+    .details-body,
+    .panel-container,
+    .charts,
+    .links,
+    .filter,
     .parameter,
-    .notes, 
+    .notes,
     .sharing {
         flex: 0 1 auto;
         overflow: auto;
@@ -362,6 +363,6 @@ export default {
 
     .charts {
         width: 100%;
-        box-sizing: border-box; 
+        box-sizing: border-box;
     }
 </style>

--- a/simulationTool/components/Job/JobExecution.vue
+++ b/simulationTool/components/Job/JobExecution.vue
@@ -4,6 +4,7 @@ import SectionHeader from "../SectionHeader.vue";
 import JobExecutionInput from "./JobExecutionInput.vue";
 import AsyncWrapper from "../AsyncWrapper.vue";
 import ProcessSelect from "../Process/ProcessSelect.vue";
+import Config from "../../../../portal/simulation/config";
 
 export default {
     name: "JobExecution",
@@ -73,7 +74,7 @@ export default {
 
             try {
                 this.requestState.loading = true;
-                const response = await fetch(`/api/processes/${processId}`,{
+                const response = await fetch(`${Config.simulationApiUrl}/processes/${processId}`,{
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders
@@ -147,7 +148,7 @@ export default {
 
                 try {
                     this.executionRequestState.loading = true;
-                    const response = await fetch(`/api/processes/${this.selectedProcessId}/execution`, {
+                    const response = await fetch(`${Config.simulationApiUrl}/processes/${this.selectedProcessId}/execution`, {
                         method: "POST",
                         body: JSON.stringify({
                             job_name,

--- a/simulationTool/components/Process/ProcessDetails.vue
+++ b/simulationTool/components/Process/ProcessDetails.vue
@@ -2,6 +2,7 @@
 import { mapMutations, mapGetters } from "vuex";
 import SectionHeader from "../SectionHeader.vue";
 import AsyncWrapper from "../AsyncWrapper.vue";
+import Config from "../../../../portal/simulation/config";
 
 export default {
     name: "ProcessDetails",
@@ -47,7 +48,7 @@ export default {
 
             try {
                 this.requestState.loading = true;
-                const response = await fetch(`/api/processes/${processId}`,{
+                const response = await fetch(`${Config.simulationApiUrl}/processes/${processId}`,{
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders

--- a/simulationTool/components/Sharing/SharingPanel.vue
+++ b/simulationTool/components/Sharing/SharingPanel.vue
@@ -2,6 +2,7 @@
 import { mapGetters } from "vuex";
 import AsyncWrapper from '../AsyncWrapper.vue';
 import UserDisplay from "../UserDisplay.vue";
+import Config from "../../../../portal/simulation/config";
 
 export default {
     name: "SharingPanel",
@@ -47,7 +48,7 @@ export default {
             }
             try {
                 this.requestState.loading = true;
-                const response = await fetch(`/api/${this.endPoint}/${this.entityId}/users`,{
+                const response = await fetch(`${Config.simulationApiUrl}/${this.endPoint}/${this.entityId}/users`,{
                     headers: {
                         "Content-Type": "application/json",
                         ...additionalHeaders
@@ -71,7 +72,7 @@ export default {
             }
             try {
                 this.requestState.loading = true;
-                const response = await fetch(`/api/${this.endPoint}/${this.entityId}/share/${this.email}`,{
+                const response = await fetch(`${Config.simulationApiUrl}/${this.endPoint}/${this.entityId}/share/${this.email}`,{
                     headers: {
                         Authorization: `Bearer ${this.accessToken}`
                     }

--- a/simulationTool/store/actions.js
+++ b/simulationTool/store/actions.js
@@ -1,4 +1,4 @@
-import rawLayerList from "@masterportal/masterportalapi/src/rawLayerList";
+import Config from "../../../portal/simulation/config";
 
 const actions = {
     /**
@@ -18,7 +18,7 @@ const actions = {
         commit("setProcessesLoading", true);
 
         try {
-            const response = await fetch(`/api/processes/`, {
+            const response = await fetch(`${Config.simulationApiUrl}/processes/`, {
                     headers: {
                         "content-type": "application/json",
                         ...additionalHeaders
@@ -46,7 +46,7 @@ const actions = {
 
         try {
             const response = await fetch(
-                `/api/jobs/?include_ensembles`,
+                `${Config.simulationApiUrl}/jobs/?include_ensembles`,
                 {
                     headers: {
                         "content-type": "application/json",
@@ -72,15 +72,13 @@ const actions = {
 
         try {
             const response = await fetch(
-                `/api/ensembles/`,
+                `${Config.simulationApiUrl}/ensembles/`,
                 {
                     headers: {
                         "content-type": "application/json",
                         Authorization: `Bearer ${rootGetters["Modules/Login/accessToken"]}`
                     }
                 }).then((res) => res.json());
-
-            // TODO: this might changed in the backend
             commit("setEnsembles", response);
         } catch (error) {
             console.error(error);
@@ -98,7 +96,7 @@ const actions = {
         commit("setEnsemblesLoading", true);
 
         try {
-            const response = await fetch(`/api/ensembles/${ensembleId}`, {
+            const response = await fetch(`${Config.simulationApiUrl}/ensembles/${ensembleId}`, {
                 method: "DELETE",
                 headers: {
                     "Content-Type": "application/json",
@@ -129,7 +127,7 @@ const actions = {
 
         const fetchPromise = (async () => {
             const accessToken = rootGetters["Modules/Login/accessToken"];
-            const response = await fetch(`/api/users/${user_id}/details`, {
+            const response = await fetch(`${Config.simulationApiUrl}/users/${user_id}/details`, {
                 headers: {
                     "Content-Type": "application/json",
                     Authorization: `Bearer ${accessToken}`


### PR DESCRIPTION
This replaces the usage of relative urls to the API endpoint with the value from the config.

Closes #69 