### PR TITLE
Prevent loading data that is already present

### DIFF
--- a/simulationTool/components/Ensemble/EnsembleDetails.vue
+++ b/simulationTool/components/Ensemble/EnsembleDetails.vue
@@ -49,7 +49,8 @@ export default {
     computed: {
         ...mapGetters("Modules/SimulationTool", [
             "selectedEnsembleId",
-            "jobs"
+            "jobs",
+            "jobResultData"
         ]),
         ...mapGetters("Modules/Login", [
             "accessToken",
@@ -177,6 +178,10 @@ export default {
                 const newJobData = {};
                 for (const job of jobs) {
                     if (job.status === 'successful') {
+                        // check if data is already in store
+                        if (this.jobResultData[job.jobID]) {
+                            continue;
+                        }
                         this.jobResultsRequestState.loading = true;
                         const url = job?.links?.[0]?.href;
                         if (!url) {

--- a/simulationTool/components/Job/JobDetails.vue
+++ b/simulationTool/components/Job/JobDetails.vue
@@ -101,6 +101,11 @@ export default {
             }
         },
         async fetchJobResultData() {
+            // check if data is already in store
+            if (this.jobResultData[this.selectedJobId]) {
+                return;
+            }
+
             if (this.intervalId) {
                 window.clearInterval(this.intervalId);
             }


### PR DESCRIPTION
This prevents loading jobResultData that is already in the store.