### PR TITLE
Get graph configuration by provider

### DIFF
--- a/simulationTool/components/Diagramm/Chart.vue
+++ b/simulationTool/components/Diagramm/Chart.vue
@@ -66,11 +66,13 @@ export default {
       }
     },
     getPlotlyData() {
-      if (!this.jobResultData || !this.type || Object.keys(this.chartConfigs).length === 0) {
+      const jobIds = Object.keys(this.chartConfigs)
+
+      if (!this.jobResultData || !this.type || jobIds.length === 0) {
         return [];
       }
 
-      const unsortedTraces = Object.keys(this.chartConfigs).map(jobId => {
+      const unsortedTraces = jobIds.map(jobId => {
         const chartConfig = this.chartConfigs[jobId];
 
         const root = this.getValue(this.jobResultData[jobId], chartConfig.rootProp);

--- a/simulationTool/components/Diagramm/ChartSettings.vue
+++ b/simulationTool/components/Diagramm/ChartSettings.vue
@@ -18,7 +18,7 @@ export default {
     }
   },
   computed: {
-    ...mapGetters("Modules/SimulationTool", ["jobResultData"])
+    ...mapGetters("Modules/SimulationTool", ["jobResultData", "jobs"])
   },
   methods: {
     getValue(obj, prop) {
@@ -27,6 +27,10 @@ export default {
       } catch {
         return undefined;
       }
+    },
+    getName(jobId) {
+      const job = this.jobs.find(job => job.jobID === jobId);
+      return job ? job.name : jobId;
     },
     getDataNode(jobId) {
       if (!this.chartConfigs[jobId]?.rootProp) {
@@ -60,7 +64,7 @@ export default {
       </select>
     </div>
     <template v-for="(value, jobId) in this.jobResultData" :key="jobId">
-      <span>{{ jobId }}</span>
+      <span>{{ this.getName(jobId) }}</span>
       <div class="input-wrapper prop-path-wrapper">
         <label>{{ $t('additional:modules.tools.simulationTool.chartDataRootProperty') }}</label>
         <PropPathSelector

--- a/simulationTool/components/Diagramm/Diagramm.vue
+++ b/simulationTool/components/Diagramm/Diagramm.vue
@@ -19,6 +19,32 @@ export default {
       activePanel: 'settings'
     };
   },
+  watch: {
+    jobResultData: {
+      // get configured graph properties from providers
+      handler(newValue) {
+        const jobIds = Object.keys(newValue);
+        const jobs = this.jobs;
+        const providers = this.providers;
+        for (const jobId of jobIds) {
+          if (!this.chartConfigs[jobId]) {
+            this.chartConfigs[jobId] = { xProp: '', yProp: '', rootProp: '' };
+          }
+          const job = jobs.find(job => job.jobID === jobId);
+          if (!job) continue;
+          const [serverName, processName] = job.processID.split(":");
+          const config = providers?.[serverName]?.processes?.[processName]?.["graph-properties"];
+          if (!config) continue;
+          this.chartConfigs[jobId] = {
+            xProp: config["x-path"] || '',
+            yProp: config["y-path"] || '',
+            rootProp: config["root-path"] || ''
+          };
+        }
+      },
+      immediate: true
+    }
+  },
   methods: {
     togglePanel() {
       this.activePanel = this.activePanel === 'settings' ? 'chart' : 'settings';
@@ -33,7 +59,7 @@ export default {
     },
   },
   computed: {
-    ...mapGetters("Modules/SimulationTool", ["jobResultData"]),
+    ...mapGetters("Modules/SimulationTool", ["jobResultData", "providers", "jobs"]),
     validationMessage() {
       if (!this.atLeastOneChartIsValid()) {
         return this.$t('additional:modules.tools.simulationTool.inValidChartConfig');

--- a/simulationTool/components/Diagramm/PropPathSelector.vue
+++ b/simulationTool/components/Diagramm/PropPathSelector.vue
@@ -123,6 +123,7 @@ export default {
       top: 100%;
       left: 0;
       margin-top: 0.5rem;
+      width: 250px;
       z-index: 1000;
       background-color: white;
       border-radius: 5px;

--- a/simulationTool/components/SimulationTool.vue
+++ b/simulationTool/components/SimulationTool.vue
@@ -45,6 +45,7 @@ export default {
         this.fetchProcesses();
         this.fetchJobs();
         this.fetchEnsembles();
+        this.fetchProviders();
     },
     /**
      * Put initialize here if mounting occurs after config parsing

--- a/simulationTool/store/actions.js
+++ b/simulationTool/store/actions.js
@@ -1,7 +1,23 @@
 import Config from "../../../portal/simulation/config";
 
 const actions = {
-    async fetchProcesses ({state, commit, rootGetters}) {
+    async fetchProviders ({ commit }) {
+        commit("setProvidersLoading", true);
+        try {
+            const response = await fetch(`${Config.simulationApiUrl}/processes/providers`, {
+                    headers: {
+                        "content-type": "application/json"
+                    }
+                }).then((res) => res.json());
+            commit("setProviders", response);
+        } catch (error) {
+            console.error(error);
+        } finally {
+            commit("setProvidersLoading", false);
+        }
+    },
+
+    async fetchProcesses ({ commit, rootGetters}) {
         let additionalHeaders = {};
         if (rootGetters["Modules/Login/loggedIn"]) {
             additionalHeaders = {
@@ -28,7 +44,7 @@ const actions = {
 
     },
 
-    async fetchJobs ({state, commit, rootGetters}) {
+    async fetchJobs ({ commit, rootGetters}) {
         let additionalHeaders = {};
         if (rootGetters["Modules/Login/loggedIn"]) {
             additionalHeaders = {
@@ -57,7 +73,7 @@ const actions = {
 
     },
 
-    async fetchEnsembles ({state, commit, rootGetters}) {
+    async fetchEnsembles ({ commit, rootGetters}) {
         if (!rootGetters["Modules/Login/loggedIn"]) {
             return;
         }
@@ -82,7 +98,7 @@ const actions = {
 
     },
 
-    async deleteEnsembleById ({state, commit, rootGetters}, ensembleId) {
+    async deleteEnsembleById ({ commit, rootGetters}, ensembleId) {
         if (!rootGetters["Modules/Login/loggedIn"]) {
             return;
         }

--- a/simulationTool/store/state.js
+++ b/simulationTool/store/state.js
@@ -11,6 +11,8 @@
  * @property {Object|null} process the current process
  * @property {Array.<Object>} processes a list of processes
  * @property {boolean} processesLoading flag indicating if processes are loading
+ * @property {Array.<Object>} providers a list of providers
+ * @property {boolean} providersLoading flag indicating if providers are loading
  * @property {string|null} selectedEnsembleId the selected ensemble id
  * @property {string|null} selectedJobId the selected job id
  * @property {string|null} selectedProcessId the selected process id
@@ -27,6 +29,8 @@ const state = {
     process: null,
     processes: [],
     processesLoading: false,
+    providers: [],
+    providersLoading: false,
     selectedEnsembleId: null,
     selectedJobId: null,
     selectedProcessId: null,


### PR DESCRIPTION
This fetches the providers configuration via `/api/processes/providers` and sets the configured properties for the corresponding jobs.

:warning: This requires https://github.com/citysciencelab/urban-model-platform/pull/74 to be merged. Configuration is documented in the ump.