### PR TITLE
fix: revert images name change since the images are not in the repo yet

### DIFF
--- a/simulationTool/components/Process/ProcessCard.vue
+++ b/simulationTool/components/Process/ProcessCard.vue
@@ -18,7 +18,7 @@ export default {
         },
         getProcessImageSource (process) {
             const image = process?.links?.find(({type}) => type === "image");
-            return image ? image : "resources/img/Process_placeholder.png";
+            return image ? image : "resources/img/DALLE_Placeholder2.png";
         }
     }
 };

--- a/simulationTool/components/Process/ProcessDetails.vue
+++ b/simulationTool/components/Process/ProcessDetails.vue
@@ -70,7 +70,7 @@ export default {
         },
         getProcessImageSource (process) {
             const image = process?.links?.find(({type}) => type === "image");
-            return image ? image : "resources/img/Process_placeholder.png";
+            return image ? image : "resources/img/DALLE_Placeholder2.png";
         }
     },
 };


### PR DESCRIPTION
Since the images are not in the repository yet this needs to be reverted temporary.